### PR TITLE
feat(store): add AO and BT (UK)

### DIFF
--- a/docs/reference/filter.md
+++ b/docs/reference/filter.md
@@ -58,6 +58,7 @@ Used with the `STORES` variable.
 | AMD | IT | `amd-it`|
 | AMD | UK | `amd-uk`|
 | AntOnline | US | `antonline`|
+| AO | UK | `ao`|
 | Argos | UK | `argos`|
 | Argos | IE | `argos-ie`|
 | Aria PC | UK | `aria`|
@@ -72,6 +73,7 @@ Used with the `STORES` variable.
 | Box | UK | `box`|
 | BPCTech | AU | `bpctech`|
 | BPM-Power | IT | `bpm-power`|
+| BT | UK | `bt`|
 | CanadaComputers | CA | `canadacomputers` |
 | Caseking | DE | `caseking`|
 | CCL | UK | `ccl`|

--- a/src/store/model/ao.ts
+++ b/src/store/model/ao.ts
@@ -1,0 +1,26 @@
+import {Store} from './store';
+
+export const AO: Store = {
+  currency: '£',
+  labels: {
+    outOfStock: {
+      container: 'section.centred-heading-copy strong',
+      text: ['currently unavailable'],
+    },
+  },
+  links: [
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://ao.com/brands/playstation',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 digital',
+      series: 'sonyps5de',
+      url: 'https://ao.com/brands/playstation',
+    },
+  ],
+  name: 'ao',
+};

--- a/src/store/model/bt.ts
+++ b/src/store/model/bt.ts
@@ -1,0 +1,26 @@
+import {Store} from './store';
+
+export const BT: Store = {
+  currency: '£',
+  labels: {
+    outOfStock: {
+      container: '#cms-component-content-panel-200124986 p',
+      text: ["We've sold out of our current allocation of PlayStation 5"],
+    },
+  },
+  links: [
+    {
+      brand: 'sony',
+      model: 'ps5 console',
+      series: 'sonyps5c',
+      url: 'https://shop.bt.com/mini-sites/gaming',
+    },
+    {
+      brand: 'sony',
+      model: 'ps5 digital',
+      series: 'sonyps5de',
+      url: 'https://shop.bt.com/mini-sites/gaming',
+    },
+  ],
+  name: 'bt',
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -22,6 +22,7 @@ import {AmdDe} from './amd-de';
 import {AmdIt} from './amd-it';
 import {AmdUk} from './amd-uk';
 import {AntOnline} from './antonline';
+import {AO} from './ao';
 import {Argos} from './argos';
 import {ArgosIE} from './argos-ie';
 import {Aria} from './aria';
@@ -36,6 +37,7 @@ import {BestBuyCa} from './bestbuy-ca';
 import {Box} from './box';
 import {Bpctech} from './bpctech';
 import {BpmPower} from './bpmpower';
+import {BT} from './bt';
 import {CanadaComputers} from './canadacomputers';
 import {Caseking} from './caseking';
 import {Ccl} from './ccl';
@@ -168,6 +170,7 @@ export const storeList = new Map([
   [AmdIt.name, AmdIt],
   [AmdUk.name, AmdUk],
   [AntOnline.name, AntOnline],
+  [AO.name, AO],
   [Argos.name, Argos],
   [ArgosIE.name, Argos],
   [Aria.name, Aria],
@@ -182,6 +185,7 @@ export const storeList = new Map([
   [Box.name, Box],
   [Bpctech.name, Bpctech],
   [BpmPower.name, BpmPower],
+  [BT.name, BT],
   [CanadaComputers.name, CanadaComputers],
   [Caseking.name, Caseking],
   [Ccl.name, Ccl],


### PR DESCRIPTION
### Description

Adds support for PS5 on AO and BT. In both cases searching for PS5 takes users to a generic landing page, so I'm targeting the messages shown there.

### Testing

Tested locally and ran them for some time in my own quest for a PS5.
